### PR TITLE
Disable redundant messages that occur when a Capability is created

### DIFF
--- a/src/Harald.WebApi/EventHandlers/SlackCapabilityCreatedDomainEventHandler.cs
+++ b/src/Harald.WebApi/EventHandlers/SlackCapabilityCreatedDomainEventHandler.cs
@@ -58,7 +58,7 @@ namespace Harald.WebApi.EventHandlers
                   $"Thank you for creating capability '{capability.Name}'.\n" +
                   $"This channel along with handle @{createUserGroupResponse.UserGroup.Handle} has been created.\n" + 
                   "Use the handle to notify capability members.\n" + 
-                  $"If you wan't to define a better handle, you can do this in the '{createUserGroupResponse.UserGroup.Name}'");
+                  $"If you want to define a better handle, you can do this in the '{createUserGroupResponse.UserGroup.Name}'");
 
                 // Pin message.
                 await _slackFacade.PinMessageToChannel(channelId, sendNotificationResponse.TimeStamp);

--- a/src/Harald.WebApi/EventHandlers/SlackMemberJoinedCapabilityDomainEventHandler.cs
+++ b/src/Harald.WebApi/EventHandlers/SlackMemberJoinedCapabilityDomainEventHandler.cs
@@ -44,11 +44,15 @@ namespace Harald.WebApi.EventHandlers
                 email: domainEvent.Payload.MemberEmail,
                 userGroupId: capability.SlackUserGroupId);
 
+            /*
+            // Disabled for now due to redundant messages. Read commit where this line is introduced in order to find further information.
+             
             // Notify user that it has been invited.
             await _slackFacade.SendNotificationToUser(
                 email: domainEvent.Payload.MemberEmail, 
                 message: 
                 $"Thank you for joining capability {capability.Name}.\nYou have been invited to corresponding Slack channel and user group.");
+            */
         }
     }
 }


### PR DESCRIPTION
Due to Slackbot already sending a message when a user is invited to a channel, the user is being sent two messages since Harald is also sending a message directly to the user with essentially the same infomation. The user is also being sent a message in the Slack channel they've been invited to. This results in up to 3 potential notifications the user is being sent, with pretty much the same purpose.

In response to that, the message Harald sends directly to the user is being disabled in this PR. This means once this PR gets merged, the user will end up with 1 message in the Slack channel they've been invited to as well as 1 message sent directly to the user from Slackbot, which is in total 2 messages.

During research of this issue, a typo was discovered in one of the messages. This has also been corrected.