### PR TITLE
Consume namespace created event, keep user up-to-date regarding Context creation process

### DIFF
--- a/src/Harald.Tests/EventHandlers/SlackAWSContextAccountCreatedEventHandlerTests.cs
+++ b/src/Harald.Tests/EventHandlers/SlackAWSContextAccountCreatedEventHandlerTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Harald.Tests.Builders;
 using Harald.Tests.TestDoubles;
 using Harald.WebApi.Domain.Events;
@@ -13,7 +15,8 @@ namespace Harald.Tests.EventHandlers
         public void can_handle_domain_event()
         {
             var slackStub = new StubSlackFacade(false);
-            var sut = new SlackAWSContextAccountCreatedEventHandler(slackStub);
+            var capabilityRepositoryStub = new StubCapabilityRepository(new List<Guid>());
+            var sut = new SlackAWSContextAccountCreatedEventHandler(slackStub, capabilityRepositoryStub);
             var eventData = DomainEventBuilder.BuildAWSContextAccountCreatedEventData();
             var @event = new AWSContextAccountCreatedDomainEvent(eventData);
 

--- a/src/Harald.Tests/TestDoubles/StubSlackFacade.cs
+++ b/src/Harald.Tests/TestDoubles/StubSlackFacade.cs
@@ -68,6 +68,11 @@ namespace Harald.Tests.TestDoubles
             });
         }
 
+        public Task<SendNotificationResponse> SendDelayedNotificationToChannel(string channel, string message, long delayTimeInEpoch)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public Task<SendNotificationResponse> SendNotificationToUser(string email, string message)
         {
             if (_simulateFailOnSendMessage)

--- a/src/Harald.WebApi/Domain/Events/K8sNamespaceCreatedAndAwsArnConnectedDomainEvent.cs
+++ b/src/Harald.WebApi/Domain/Events/K8sNamespaceCreatedAndAwsArnConnectedDomainEvent.cs
@@ -22,11 +22,13 @@ namespace Harald.WebApi.Domain.Events
     }
     public class K8sNamespaceCreatedAndAwsArnConnectedData
     {
+        public Guid CapabilityId { get; private set; }
         public Guid ContextId { get; private set; }
         public string NamespaceName { get; private set; }
 
-        public K8sNamespaceCreatedAndAwsArnConnectedData(Guid contextId, string namespaceName)
+        public K8sNamespaceCreatedAndAwsArnConnectedData(Guid capabilityId, Guid contextId, string namespaceName)
         {
+            CapabilityId = capabilityId;
             ContextId = contextId;
             NamespaceName = namespaceName;
         }

--- a/src/Harald.WebApi/Domain/Events/K8sNamespaceCreatedAndAwsArnConnectedDomainEvent.cs
+++ b/src/Harald.WebApi/Domain/Events/K8sNamespaceCreatedAndAwsArnConnectedDomainEvent.cs
@@ -16,7 +16,7 @@ namespace Harald.WebApi.Domain.Events
 
         public string Version { get; }
         public string EventName { get; }
-        public Guid XCorrelationId { get; }
+        public string XCorrelationId { get; }
         public string XSender { get; }
         public K8sNamespaceCreatedAndAwsArnConnectedData Payload { get; }
     }

--- a/src/Harald.WebApi/Domain/Events/K8sNamespaceCreatedAndAwsArnConnectedDomainEvent.cs
+++ b/src/Harald.WebApi/Domain/Events/K8sNamespaceCreatedAndAwsArnConnectedDomainEvent.cs
@@ -1,0 +1,34 @@
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace Harald.WebApi.Domain.Events
+{
+    public class K8sNamespaceCreatedAndAwsArnConnectedDomainEvent : IDomainEvent<K8sNamespaceCreatedAndAwsArnConnectedData>
+    {
+        public K8sNamespaceCreatedAndAwsArnConnectedDomainEvent(GeneralDomainEvent domainEvent)
+        {
+            Version = domainEvent.Version;
+            EventName = domainEvent.EventName;
+            XCorrelationId = domainEvent.XCorrelationId;
+            XSender = domainEvent.XSender;
+            Payload = (domainEvent.Payload as JObject)?.ToObject<K8sNamespaceCreatedAndAwsArnConnectedData>();
+        }
+
+        public string Version { get; }
+        public string EventName { get; }
+        public Guid XCorrelationId { get; }
+        public string XSender { get; }
+        public K8sNamespaceCreatedAndAwsArnConnectedData Payload { get; }
+    }
+    public class K8sNamespaceCreatedAndAwsArnConnectedData
+    {
+        public Guid ContextId { get; private set; }
+        public string NamespaceName { get; private set; }
+
+        public K8sNamespaceCreatedAndAwsArnConnectedData(Guid contextId, string namespaceName)
+        {
+            ContextId = contextId;
+            NamespaceName = namespaceName;
+        }
+    }
+}

--- a/src/Harald.WebApi/EventHandlers/K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler.cs
+++ b/src/Harald.WebApi/EventHandlers/K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler.cs
@@ -28,12 +28,12 @@ namespace Harald.WebApi.EventHandlers
             var capability = await _capabilityRepository.Get(domainEvent.Payload.CapabilityId);
             
             // 1st Message, instant.
-            await _slackFacade.SendNotificationToChannel(capability.SlackChannelId, $"Task status:\n{SlackContextAddedToCapabilityDomainEventHandler.CreateTaskTable(true, true, false)}");
+            await _slackFacade.SendNotificationToChannel(capability.SlackChannelId, $"Nearly there... time to grab a coffee?\n{SlackContextAddedToCapabilityDomainEventHandler.CreateTaskTable(true, true, false)}");
 
             var timeToWait = (60 * 15); // 15 Minutes
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + timeToWait;
             // 2nd Message, delayed.
-            await _slackFacade.SendDelayedNotificationToChannel(capability.SlackChannelId, $"Task status:\n{SlackContextAddedToCapabilityDomainEventHandler.CreateTaskTable(true, true, true)}", timestamp);
+            await _slackFacade.SendDelayedNotificationToChannel(capability.SlackChannelId, $"All done:\n{SlackContextAddedToCapabilityDomainEventHandler.CreateTaskTable(true, true, true)}", timestamp);
         }
     }
 }

--- a/src/Harald.WebApi/EventHandlers/K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler.cs
+++ b/src/Harald.WebApi/EventHandlers/K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler.cs
@@ -26,7 +26,14 @@ namespace Harald.WebApi.EventHandlers
         public async Task HandleAsync(K8sNamespaceCreatedAndAwsArnConnectedDomainEvent domainEvent)
         {
             var capability = await _capabilityRepository.Get(domainEvent.Payload.CapabilityId);
-            await _slackFacade.SendNotificationToChannel(capability.SlackChannelId, $"Namespace {domainEvent.Payload.NamespaceName} has been created.");
+            
+            // 1st Message, instant.
+            await _slackFacade.SendNotificationToChannel(capability.SlackChannelId, $"Task status:\n{SlackContextAddedToCapabilityDomainEventHandler.CreateTaskTable(true, true, false)}");
+
+            var timeToWait = (60 * 15); // 15 Minutes
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + timeToWait;
+            // 2nd Message, delayed.
+            await _slackFacade.SendDelayedNotificationToChannel(capability.SlackChannelId, $"Task status:\n{SlackContextAddedToCapabilityDomainEventHandler.CreateTaskTable(true, true, true)}", timestamp);
         }
     }
 }

--- a/src/Harald.WebApi/EventHandlers/K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler.cs
+++ b/src/Harald.WebApi/EventHandlers/K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler.cs
@@ -25,8 +25,8 @@ namespace Harald.WebApi.EventHandlers
 
         public async Task HandleAsync(K8sNamespaceCreatedAndAwsArnConnectedDomainEvent domainEvent)
         {
-            // Handle whatever messages one might wanna sent via Slack when said event is triggered, here.
-            _logger.LogDebug($"k8s_namespace_created_and_aws_arn_connected not in use yet. Do something with the event at EventHandlers/K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler.cs");
+            var capability = await _capabilityRepository.Get(domainEvent.Payload.CapabilityId);
+            await _slackFacade.SendNotificationToChannel(capability.SlackChannelId, $"Namespace {domainEvent.Payload.NamespaceName} has been created.");
         }
     }
 }

--- a/src/Harald.WebApi/EventHandlers/K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler.cs
+++ b/src/Harald.WebApi/EventHandlers/K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Harald.WebApi.Domain;
+using Harald.WebApi.Domain.Events;
+using Harald.WebApi.Infrastructure.Facades.Slack;
+using Microsoft.Extensions.Logging;
+
+namespace Harald.WebApi.EventHandlers
+{
+    public class K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler : IEventHandler<K8sNamespaceCreatedAndAwsArnConnectedDomainEvent>
+    {
+        private readonly ILogger<K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler> _logger;
+        private readonly ISlackFacade _slackFacade;
+        private readonly ICapabilityRepository _capabilityRepository;
+
+        public K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler(
+            ILogger<K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler> logger,
+            ISlackFacade slackFacade,
+            ICapabilityRepository capabilityRepository)
+        {
+            _logger = logger;
+            _slackFacade = slackFacade;
+            _capabilityRepository = capabilityRepository;
+        }
+
+        public async Task HandleAsync(K8sNamespaceCreatedAndAwsArnConnectedDomainEvent domainEvent)
+        {
+            // Handle whatever messages one might wanna sent via Slack when said event is triggered, here.
+            _logger.LogDebug($"k8s_namespace_created_and_aws_arn_connected not in use yet. Do something with the event at EventHandlers/K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler.cs");
+        }
+    }
+}

--- a/src/Harald.WebApi/EventHandlers/SlackAWSContextAccountCreatedEventHandler.cs
+++ b/src/Harald.WebApi/EventHandlers/SlackAWSContextAccountCreatedEventHandler.cs
@@ -42,7 +42,7 @@ namespace Harald.WebApi.EventHandlers
             
             // Send message to Capability Slack channel
             var capability = await _capabilityRepository.Get(domainEvent.Payload.CapabilityId);
-            await _slackFacade.SendNotificationToChannel(capability.SlackChannelId, $"Task status:\n{SlackContextAddedToCapabilityDomainEventHandler.CreateTaskTable(true, false, false)}");
+            await _slackFacade.SendNotificationToChannel(capability.SlackChannelId, $"Status update\n{SlackContextAddedToCapabilityDomainEventHandler.CreateTaskTable(true, false, false)}");
             
         }
     }

--- a/src/Harald.WebApi/EventHandlers/SlackAWSContextAccountCreatedEventHandler.cs
+++ b/src/Harald.WebApi/EventHandlers/SlackAWSContextAccountCreatedEventHandler.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Threading.Tasks;
+using Harald.WebApi.Domain;
 using Harald.WebApi.Domain.Events;
 using Harald.WebApi.Infrastructure.Facades.Slack;
 
@@ -8,10 +9,12 @@ namespace Harald.WebApi.EventHandlers
     public class SlackAWSContextAccountCreatedEventHandler : IEventHandler<AWSContextAccountCreatedDomainEvent>
     {
         private readonly ISlackFacade _slackFacade;
+        private readonly ICapabilityRepository _capabilityRepository;
 
-        public SlackAWSContextAccountCreatedEventHandler(ISlackFacade slackFacade)
+        public SlackAWSContextAccountCreatedEventHandler(ISlackFacade slackFacade, ICapabilityRepository capabilityRepository)
         {
             _slackFacade = slackFacade;
+            _capabilityRepository = capabilityRepository;
         }
 
         public async Task HandleAsync(AWSContextAccountCreatedDomainEvent domainEvent)
@@ -36,6 +39,11 @@ namespace Harald.WebApi.EventHandlers
 
             var hardCodedDedChannelId = "GFYE9B99Q";
             await _slackFacade.SendNotificationToChannel(hardCodedDedChannelId, sb.ToString());
+            
+            // Send message to Capability Slack channel
+            var capability = await _capabilityRepository.Get(domainEvent.Payload.CapabilityId);
+            await _slackFacade.SendNotificationToChannel(capability.SlackChannelId, $"Task status:\n{SlackContextAddedToCapabilityDomainEventHandler.CreateTaskTable(true, false, false)}");
+            
         }
     }
 }

--- a/src/Harald.WebApi/EventHandlers/SlackContextAddedToCapabilityDomainEventHandler.cs
+++ b/src/Harald.WebApi/EventHandlers/SlackContextAddedToCapabilityDomainEventHandler.cs
@@ -28,7 +28,7 @@ namespace Harald.WebApi.EventHandlers
             
             // Send message to Capability Slack channel
             await _slackFacade.SendNotificationToChannel(capability.SlackChannelId,
-                $"Your context \"{domainEvent.Payload.ContextName}\" has been added. Following tasks are in progress:" +
+                $"We're working on setting up your environment. Currently the following resources are being provisioned and are awaiting status updates" +
                 $"\n" +
                 $"{CreateTaskTable(false, false, false)}");
         }
@@ -56,9 +56,9 @@ namespace Harald.WebApi.EventHandlers
 
         public static string CreateTaskTable(bool awsAccDone, bool k8sCreatedDone, bool adsyncDone)
         {
-            var awsMessage = awsAccDone ? $":heavy_check_mark: AWS Account\n" : $":black_large_square: AWS Account\n";
-            var k8sMessage = k8sCreatedDone ? $":heavy_check_mark: K8s Namespace created\n" : $":black_large_square: K8s Namespace created\n";
-            var adsyncMessage = adsyncDone ? $":heavy_check_mark: ADSync\n" : $":black_large_square: ADSync\n";
+            var awsMessage = awsAccDone ? $":heavy_check_mark: AWS account provisioned\n" : $":white_check_mark: AWS account provisioned\n";
+            var k8sMessage = k8sCreatedDone ? $":heavy_check_mark: Kubernetes namespace created\n" : $":white_check_mark: Kubernetes namespace created\n";
+            var adsyncMessage = adsyncDone ? $":heavy_check_mark: AWS and Kubernetes account enrollment\n" : $":white_check_mark: AWS and Kubernetes account enrollment\n";
 
             return $"{awsMessage}{k8sMessage}{adsyncMessage}";
         }

--- a/src/Harald.WebApi/EventHandlers/SlackContextAddedToCapabilityDomainEventHandler.cs
+++ b/src/Harald.WebApi/EventHandlers/SlackContextAddedToCapabilityDomainEventHandler.cs
@@ -25,6 +25,12 @@ namespace Harald.WebApi.EventHandlers
 
             var hardCodedDedChannelId = "GFYE9B99Q";
             await _slackFacade.SendNotificationToChannel(hardCodedDedChannelId, message);
+            
+            // Send message to Capability Slack channel
+            await _slackFacade.SendNotificationToChannel(capability.SlackChannelId,
+                $"Your context \"{domainEvent.Payload.ContextName}\" has been added. Following tasks are in progress:" +
+                $"\n" +
+                $"{CreateTaskTable(false, false, false)}");
         }
 
         public static string CreateMessage(ContextAddedToCapabilityDomainEvent domainEvent, Capability capability)
@@ -46,6 +52,15 @@ namespace Harald.WebApi.EventHandlers
                           "./generate-tfvars.sh";
 
             return message;
+        }
+
+        public static string CreateTaskTable(bool awsAccDone, bool k8sCreatedDone, bool adsyncDone)
+        {
+            var awsMessage = awsAccDone ? $":heavy_check_mark: AWS Account\n" : $":black_large_square: AWS Account\n";
+            var k8sMessage = k8sCreatedDone ? $":heavy_check_mark: K8s Namespace created\n" : $":black_large_square: K8s Namespace created\n";
+            var adsyncMessage = adsyncDone ? $":heavy_check_mark: ADSync\n" : $":black_large_square: ADSync\n";
+
+            return $"{awsMessage}{k8sMessage}{adsyncMessage}";
         }
     }
 }

--- a/src/Harald.WebApi/Infrastructure/Facades/Slack/ISlackFacade.cs
+++ b/src/Harald.WebApi/Infrastructure/Facades/Slack/ISlackFacade.cs
@@ -5,6 +5,7 @@ namespace Harald.WebApi.Infrastructure.Facades.Slack
     public interface ISlackFacade
     {
         Task<SendNotificationResponse> SendNotificationToChannel(string channel, string message);
+        Task<SendNotificationResponse> SendDelayedNotificationToChannel(string channel, string message, long delayTimeInEpoch);
         Task<SendNotificationResponse> SendNotificationToUser(string email, string message);
         Task<GeneralResponse> PinMessageToChannel(string channel, string messageTimeStamp);
         Task<CreateChannelResponse> CreateChannel(string channelName);

--- a/src/Harald.WebApi/Infrastructure/Facades/Slack/SlackFacade.cs
+++ b/src/Harald.WebApi/Infrastructure/Facades/Slack/SlackFacade.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -39,6 +40,20 @@ namespace Harald.WebApi.Infrastructure.Facades.Slack
             var payload = _serializer.GetPayload(new { Channel = channel, Text = message });
 
             var response = await _client.PostAsync("/api/chat.postMessage", payload);
+            response.EnsureSuccessStatusCode();
+
+            var content = await response.Content.ReadAsStringAsync();
+            var sendNotificationResponse = _serializer.Deserialize<SendNotificationResponse>(content);
+
+            return sendNotificationResponse;
+        }
+
+        public async Task<SendNotificationResponse> SendDelayedNotificationToChannel(string channel, string message, long delayTimeInEpoch)
+        {
+            var payload = _serializer.GetPayload(new { Channel = channel, Text = message, post_at = delayTimeInEpoch });
+            var raaa = await payload.ReadAsStringAsync();
+
+            var response = await _client.PostAsync("/api/chat.scheduleMessage", payload);
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();

--- a/src/Harald.WebApi/Startup.cs
+++ b/src/Harald.WebApi/Startup.cs
@@ -84,6 +84,7 @@ namespace Harald.WebApi
             services.AddTransient<IEventHandler<MemberLeftCapabilityDomainEvent>, SlackMemberLeftCapabilityDomainEventHandler>();
             services.AddTransient<IEventHandler<ContextAddedToCapabilityDomainEvent>, SlackContextAddedToCapabilityDomainEventHandler>();
             services.AddTransient<IEventHandler<AWSContextAccountCreatedDomainEvent>, SlackAWSContextAccountCreatedEventHandler>();
+            services.AddTransient<IEventHandler<K8sNamespaceCreatedAndAwsArnConnectedDomainEvent>, K8sNamespaceCreatedAndAwsArnConnectedDomainEventHandler>();
             services.AddTransient<EventHandlerFactory>();
 
             var topic = "build.capabilities";
@@ -103,6 +104,9 @@ namespace Harald.WebApi
                     topicName: topic)
                 .Register<AWSContextAccountCreatedDomainEvent>(
                     eventName: "aws_context_account_created",
+                    topicName: topic)
+                .Register<K8sNamespaceCreatedAndAwsArnConnectedDomainEvent>(
+                    eventName: "k8s_namespace_created_and_aws_arn_connected",
                     topicName: topic);
            
                 var serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
The newly created "k8s_namespace_created_and_aws_arn_connected" event from k8s-janitor has been added, and is also being consumed in Harald. Since this addition has yet to be merged into k8s-janitor, it is **crucial** that **this PR isn't merged** before that occurs. The k8s-janitor PR can be found at https://github.com/dfds/k8s-janitor/pull/5

In order to keep the user up-to-date in terms of when they can use their newly created Context, new messages has been added, and it goes like this:

1. User creates a new Context
2. A message is sent to the Capability's attached Slack channel, looking like this
```
Your context "InsertContextNameHere" has been added. Following tasks are in progress:
■  AWS Account
■  K8s namespace created
■  ADSync
```
3. When an AWS account has been added, a new message will be sent to the same channel.
```
✅ AWS Account
■  K8s namespace created
■  ADSync
```
4. When the K8s namespace has been created, a new message will be sent to the same channel.
```
✅ AWS Account
✅ K8s namespace created
■  ADSync
```
5. In combination with the previous step, another message will be created, but said message will be sent on a delay(currently 15 minutes after previous message). When that message is eventually received by the related Slack channel, it will look like this.
```
✅ AWS Account
✅ K8s namespace created
✅ ADSync
```