### PR TITLE
Event consumer more resilient against broken msgs; Added CorrelationId tracking

### DIFF
--- a/src/Harald.Tests/Messaging/EventDispatcherTests.cs
+++ b/src/Harald.Tests/Messaging/EventDispatcherTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Threading.Tasks;
+using Harald.WebApi.Domain.Events;
+using Harald.WebApi.EventHandlers;
+using Harald.WebApi.Infrastructure.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Harald.Tests.Messaging
+{
+    public class EventDispatcherTests
+    {
+        private IServiceProvider _serviceProvider;
+        
+        [Fact]
+        public async void ThrowEventMessageIncomprehensibleExceptionOnBlankMessage()
+        {
+            var serviceProvider = GetPreconfiguredServiceProvider();
+            const string message = "";
+            var ex = await Assert.ThrowsAsync<EventMessageIncomprehensible>(async () =>
+            {
+                await serviceProvider.GetRequiredService<IEventDispatcher>().Send(message, null);
+            });
+            
+            Assert.Equal("Received a blank message", ex.Message);
+        }
+        
+        [Fact]
+        public async void ThrowEventMessageIncomprehensibleExceptionOnInvalidJson()
+        {
+            var serviceProvider = GetPreconfiguredServiceProvider();
+            const string message = "{::;;}";
+            var ex = await Assert.ThrowsAsync<EventMessageIncomprehensible>(async () =>
+            {
+                await serviceProvider.GetRequiredService<IEventDispatcher>().Send(message, null);
+            });
+            
+            Assert.Contains("Received a message that could not be deserialized from expected JSON structure. Original exception:", ex.Message);
+        }
+
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("{\"version\":\"1\",\"eventName\":\"k8s_namespace_created_and_aws_arn_connected\",\"x-correlationId\":\"00000000-0000-0000-0000-000000000000\",\"x-sender\":\"K8sJanitor.WebApi, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\",\"payload\":{\"namespaceName\":\"hellopelle\",\"contextId\":\"00000000-0000-0000-0000-000000000000\"}}")]
+        [InlineData("{\"eventDataXaxa\": \"dataaaa\"}")]
+        public async void ThrowEventTypeNotFoundExceptionOnUnknownOrUnregisteredEvent(string evtMsg)
+        {
+            var serviceProvider = GetPreconfiguredServiceProvider();
+            var ex = await Assert.ThrowsAsync<EventTypeNotFoundException>(async () =>
+            {
+                await serviceProvider.GetRequiredService<IEventDispatcher>().Send(evtMsg, null);
+            });
+
+            Assert.Contains("Error! Could not determine \"event instance type\" due to no registration was found for type", ex.Message);
+        }
+
+        [Theory]
+        [InlineData("{\"version\":\"1\",\"eventName\":\"member_joined_capability\",\"x-correlationId\":\"00000000-0000-0000-0000-000000000000\",\"x-sender\":\"K8sJanitor.WebApi, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\",\"payload\":{\"namespaceName\":\"hellopelle\",\"contextId\":\"00000000-0000-0000-0000-000000000000\"}}")]
+        public async void InterpretAndSendEventToHandler(string evtMsg)
+        {
+            var serviceProvider = GetPreconfiguredServiceProvider();
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var eventDispatcher = scope.ServiceProvider.GetRequiredService<IEventDispatcher>();
+                await eventDispatcher.Send(evtMsg, scope);
+            }
+            //Assert.Contains("Error! Could not determine \"event instance type\" due to no registration was found for type", ex.Message);
+        }
+
+        private IServiceProvider GetPreconfiguredServiceProvider()
+        {
+
+            var loggerFactory = new LoggerFactory();
+            var logger = new Logger<EventDispatcher>(loggerFactory);
+            var domainEventRegistry = new DomainEventRegistry();
+            const string topic = "build.capabilities";
+
+            domainEventRegistry.Register<MemberJoinedCapabilityDomainEvent>(
+                eventName: "member_joined_capability",
+                topicName: topic);
+            
+            var eventHandlerFactory = new EventHandlerFactory();
+            
+            var serviceProvider = new ServiceCollection()
+                .AddLogging()
+                .AddTransient<IEventHandler<MemberJoinedCapabilityDomainEvent>, GenericEventHandler<MemberJoinedCapabilityDomainEvent>>()
+                .AddTransient<EventHandlerFactory>()
+                .AddSingleton(domainEventRegistry)
+                .AddTransient<IEventDispatcher, EventDispatcher>()
+                .BuildServiceProvider();
+
+            return serviceProvider;
+        }
+
+    }
+
+    public class GenericEventHandler<T> : IEventHandler<T>
+    {
+        public async Task HandleAsync(T domainEvent)
+        {
+            Console.WriteLine("GenericEventHandler called");
+        }
+    }
+}

--- a/src/Harald.WebApi/Infrastructure/Messaging/ConsumerHostedService.cs
+++ b/src/Harald.WebApi/Infrastructure/Messaging/ConsumerHostedService.cs
@@ -68,6 +68,11 @@ namespace Harald.WebApi.Infrastructure.Messaging
                                         _logger.LogWarning($"Message skipped. Exception message: {ex.Message}", ex);
                                         await consumer.CommitAsync(msg);
                                     }
+                                    catch (EventMessageIncomprehensible ex)
+                                    {
+                                        _logger.LogWarning(ex, $"Encountered a message that was irrecoverably incomprehensible. Skipping. Raw message included {msg} with value '{msg.Value}'");
+                                        await consumer.CommitAsync(msg);
+                                    }
                                     catch (Exception ex)
                                     {
                                         _logger.LogError($"Error consuming event. Exception message: {ex.Message}", ex);

--- a/src/Harald.WebApi/Infrastructure/Messaging/EventDispatcher.cs
+++ b/src/Harald.WebApi/Infrastructure/Messaging/EventDispatcher.cs
@@ -34,7 +34,7 @@ namespace Harald.WebApi.Infrastructure.Messaging
             }
             catch (JsonReaderException ex)
             {
-                throw new EventMessageIncomprehensible("Received a message that could not be deserialized from expected JSON structure.");
+                throw new EventMessageIncomprehensible($"Received a message that could not be deserialized from expected JSON structure. Original exception: {ex}");
             }
             await SendAsync(generalDomainEventObj, serviceScope);
         }

--- a/src/Harald.WebApi/Infrastructure/Messaging/EventDispatcher.cs
+++ b/src/Harald.WebApi/Infrastructure/Messaging/EventDispatcher.cs
@@ -28,16 +28,15 @@ namespace Harald.WebApi.Infrastructure.Messaging
 
         public async Task Send(string generalDomainEventJson, IServiceScope serviceScope)
         {
-            GeneralDomainEvent generalDomainEventObj = new GeneralDomainEvent("", "", "", "", "");
             try
             {
-                generalDomainEventObj = JsonConvert.DeserializeObject<GeneralDomainEvent>(generalDomainEventJson);
+                var generalDomainEventObj = JsonConvert.DeserializeObject<GeneralDomainEvent>(generalDomainEventJson);
+                await SendAsync(generalDomainEventObj, serviceScope);
             }
             catch (JsonReaderException ex)
             {
                 throw new EventMessageIncomprehensible($"Received a message that could not be deserialized from expected JSON structure. Original exception: {ex}");
             }
-            await SendAsync(generalDomainEventObj, serviceScope);
         }
 
         public async Task SendAsync(GeneralDomainEvent generalDomainEvent, IServiceScope serviceScope)

--- a/src/Harald.WebApi/Infrastructure/Messaging/MessagingException.cs
+++ b/src/Harald.WebApi/Infrastructure/Messaging/MessagingException.cs
@@ -16,6 +16,13 @@ namespace Harald.WebApi.Infrastructure.Messaging
         }
     }
 
+    public class EventMessageIncomprehensible : MessagingException
+    {
+        public EventMessageIncomprehensible(string message) : base(message)
+        {
+        }
+    }
+
     public class EventHandlerNotFoundException : MessagingException
     {
         public EventHandlerNotFoundException(string message) : base(message)


### PR DESCRIPTION
We've recently had issues with events disappearing and consumption of events failing without descriptive errors. This PR is intended to partly remedy that, with an added bonus of CorrelationId tracking.