### PR TITLE
Not failing with nullreference exception in case payload is bad

### DIFF
--- a/src/Harald.WebApi/Infrastructure/Facades/Slack/SlackFacade.cs
+++ b/src/Harald.WebApi/Infrastructure/Facades/Slack/SlackFacade.cs
@@ -173,14 +173,14 @@ namespace Harald.WebApi.Infrastructure.Facades.Slack
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();
-            var users = _serializer.GetTokenValue<List<string>>(content, "['users']");
             
             var generalResponse = _serializer.Deserialize<GeneralResponse>(content);
             if (!generalResponse.Ok)
             {
                 throw new SlackFacadeException($"API error: {generalResponse.Error}");
             }
-
+            
+            var users = _serializer.GetTokenValue<List<string>>(content, "['users']");
             return users;
         }
 


### PR DESCRIPTION
We assert error in response (due to bad request), before accessing elements in payload.