### PR TITLE
Updating the base image to point to MS new official .NET Core image r…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2.1-aspnetcore-runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
 
 # SSL
 RUN curl -o /tmp/rds-combined-ca-bundle.pem https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem \


### PR DESCRIPTION
Microsoft has moved their official .NET Core images to a new Azure based ACR. I have updated our base image reference to reflect this. Read more about it here @ https://devblogs.microsoft.com/dotnet/net-core-container-images-now-published-to-microsoft-container-registry/