### PR TITLE
fix: Changed ExternalEventMetaDataStore from Transient to Scoped

### DIFF
--- a/src/Harald.WebApi/Startup.cs
+++ b/src/Harald.WebApi/Startup.cs
@@ -119,7 +119,7 @@ namespace Harald.WebApi
 
             services.AddTransient<IEventDispatcher, EventDispatcher>();
 
-            services.AddTransient<ExternalEventMetaDataStore>();
+            services.AddScoped<ExternalEventMetaDataStore>();
             services.AddTransient<KafkaConsumerFactory.KafkaConfiguration>();
             services.AddTransient<KafkaConsumerFactory>();
         }


### PR DESCRIPTION
It was spotted by SRE today that a couple of the "Context added to capability" messages sent by Harald didn't include the CorrelationId. Upon further investigation the logs show that Harald does indeed receive the expected CorrelationId(s) but doesn't include them in its messages.

A quick look at a recent PR[(#22)](https://github.com/dfds/harald/pull/22) reveals that the way Harald handles "event metadata" such as CorrelationId has been changed. 

It is now stored in a class called "ExternalEventMetaDataStore". That in and of itself is fine, however the way it is used in terms of DI, has resulted in the situation mentioned in the beginning.

It is being made available for DI in startup.cs by the following line:
`services.AddTransient<ExternalEventMetaDataStore>();`

According to the [MSDN docs](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2#transient), Transient objects _are created each time they're requested from the service container_.

Assuming that is the case, with the way "ExternalEventMetaDataStore" is being used in Harald, this would indeed end up being an issue.


Following the flow where Harald receives an event, the first "ExternalEventMetaDataStore" object is created during creation of "EventDispatcher". During execution of its "SendAsync" method, it will populate the first "ExternalEventMetaDataStore" object with the expected data, including CorrelationId. Afterwards, it'll in this case create a "SlackContextAddedToCapabilityDomainEventHandler" object, and for its constructor attempt to use DI to populate it. It expects a "ExternalEventMetaDataStore" object, so presumably one intended for the previously created object to be used here. However with it being of the Transient type, it'll instead give the constructor a new instance.

In this PR, I've gone ahead and changed 

`services.AddTransient<ExternalEventMetaDataStore>();`

to

`services.AddScoped<ExternalEventMetaDataStore>();`

I've tested the change above locally, by replicating one of the "ContextAddedToCapability" events from earlier today, and it is seemingly working.

It is my understanding (of the [MSDN docs](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2#scoped)) that this will ensure the presumably intended behaviour, that an empty object is created for "EventDispatcher", and that object is reused in whatever EventHandler is created within "EventDispatcher".


My understanding of the C# DI framework is rather limited, so please do correct me if I'm wrong in this assumption.