### PR TITLE
80 char slack channel name

### DIFF
--- a/src/Harald.Tests/Domain/ChannelNameTests.cs
+++ b/src/Harald.Tests/Domain/ChannelNameTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Harald.WebApi.Domain;
 using Harald.WebApi.Infrastructure.Facades.Slack;
 using Harald.WebApi.Infrastructure.Serialization;
@@ -181,9 +182,29 @@ namespace Harald.Tests.Infrastructure.Facades.Slack
         }
 
 
+        [Fact]
+        public void FixChannelNameForSlack_NameWithLength100_ReturnsValidSlackChannelName()
+        {
+            // Arrange
+            var channelNameOfLength100 = string.Join("", Enumerable
+                .Repeat(0, 100)
+                .Select(n => 
+                        (char)new Random().Next(97,123)
+                    )
+                );
+            
+            // Act
+            var fixedChannelName = ChannelName.Create(channelNameOfLength100);
+
+            // Assert
+            AssertValidSlackChannelName(fixedChannelName);
+            
+            
+        }
+
         private void AssertValidSlackChannelName(string name)
         {
-            Assert.True(name.Length <= 21);
+            Assert.True(name.Length <= 80);
             AssertValidSlackName(name);
         }
 

--- a/src/Harald.Tests/Harald.Tests.csproj
+++ b/src/Harald.Tests/Harald.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Harald.WebApi/Domain/ChannelName.cs
+++ b/src/Harald.WebApi/Domain/ChannelName.cs
@@ -8,21 +8,24 @@ namespace Harald.WebApi.Domain
         {
         }
 
+        private const int MAX_CHANNEL_NAME_LENGTH = 80;
+
         public static ChannelName Create(string source)
         {
-            // Max channel name length is 21.
-            if (source.Length > 21)
+            if (MAX_CHANNEL_NAME_LENGTH < source.Length)
             {
-                source = source.Substring(0, 21);
+                source = source.Substring(0, MAX_CHANNEL_NAME_LENGTH);
             }
 
-            var fixedChannelName = source.Replace('_', '-').ToLowerInvariant();
-            
-            
+            var fixedChannelName = source
+                .Replace('_', '-')
+                .ToLowerInvariant();
+
 
             return new ChannelName(fixedChannelName);
         }
-        public static explicit operator ChannelName(String input) 
+
+        public static explicit operator ChannelName(String input)
         {
             return ChannelName.Create(input);
         }

--- a/src/Harald.WebApi/Infrastructure/Facades/Slack/SlackFacade.cs
+++ b/src/Harald.WebApi/Infrastructure/Facades/Slack/SlackFacade.cs
@@ -20,8 +20,7 @@ namespace Harald.WebApi.Infrastructure.Facades.Slack
 
         public async Task<CreateChannelResponse> CreateChannel(ChannelName channelName)
         {
-            var validChannelName = ChannelName.Create(channelName);
-            var payload = _serializer.GetPayload(new {Name = validChannelName.ToString(), Validate = true});
+            var payload = _serializer.GetPayload(new {Name = channelName.ToString(), Validate = true});
             var response = await _client.PostAsync("/api/channels.create", payload);
 
             return await Parse<CreateChannelResponse>(response);


### PR DESCRIPTION
channel name will now cut of at 80 chars instead of 21.