### PR TITLE
Merge capabilites and slack conversations

### DIFF
--- a/integration-tests/Harald.IntegrationTests/Features/Connections/Add2ConnectionsToClientScenario.cs
+++ b/integration-tests/Harald.IntegrationTests/Features/Connections/Add2ConnectionsToClientScenario.cs
@@ -1,23 +1,46 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Harald.IntegrationTests.Features.Infrastructure;
+using Harald.IntegrationTests.Features.Infrastructure.Model;
 using Xunit;
 
 namespace Harald.IntegrationTests.Features.Connections
 {
     public class Add2ConnectionsToClientScenario
     {
+        private SlackApiServerSpyClient slackApiServerSpyClient = new SlackApiServerSpyClient();
+        
+        private Guid _capabilityId;
+        private SlackConversationDto _conversation1Dto;
+        private SlackConversationDto _conversation2Dto;
+        
         [Fact]
         public async Task Add2ConnectionsToClientScenarioRecipe()
         {
-            var capabilityId = await Given_a_capability();
-            await When_connection_is_added(capabilityId);
-            await And_connection_is_added(capabilityId);
-            await Then_3_connection_should_be_in_the_capability_connections_list(capabilityId);
+            await Given_a_clean_slack_api_server_spy();
+            await and_a_capability();
+            await and_a_slack_channel_named_channel1();
+            await and_a_slack_channel_named_channel2();
+            await When_connection_is_added();
+            await And_connection_is_added();
+            await Then_3_connection_should_be_in_the_capability_connections_list();
         }
 
-        private async Task<Guid> Given_a_capability()
+        private async Task and_a_slack_channel_named_channel1()
+        {
+            _conversation1Dto = await slackApiServerSpyClient.ChannelsCreateAsync("channel1");
+        }
+        private async Task and_a_slack_channel_named_channel2()
+        {
+            _conversation2Dto = await slackApiServerSpyClient.ChannelsCreateAsync("channel2");
+        }
+        private async Task Given_a_clean_slack_api_server_spy()
+        {
+            await slackApiServerSpyClient.ResetAsync();
+        }
+        private async Task and_a_capability()
         {
             var capabilityId = Guid.NewGuid();
             var kafkaClient = new KafkaClient();
@@ -31,41 +54,41 @@ namespace Harald.IntegrationTests.Features.Connections
 
             Thread.Sleep(1500); // Magic sleep that ensures that the service have complected the create operation. 
 
-            return capabilityId;
+            _capabilityId = capabilityId;
         }
 
-        private async Task When_connection_is_added(Guid capabilityId)
+        private async Task When_connection_is_added()
         {
             await ApiClient.Connections.AddAsync(
                 "VerbNoun",
-                capabilityId.ToString(),
-                "channel1",
-                "HJDPS78LS"
+                _capabilityId.ToString(),
+                _conversation1Dto.Name,
+                _conversation1Dto.Id
             );
         }
 
-        private async Task And_connection_is_added(Guid capabilityId)
+        private async Task And_connection_is_added()
         {
             await ApiClient.Connections.AddAsync(
                 "VerbNoun",
-                capabilityId.ToString(),
-                "channel2",
-                "AALF173LF"
+                _capabilityId.ToString(),
+                _conversation2Dto.Name,
+                _conversation2Dto.Id
             );
         }
 
-        private async Task Then_3_connection_should_be_in_the_capability_connections_list(Guid capabilityId)
+        private async Task Then_3_connection_should_be_in_the_capability_connections_list()
         {
             var connectionsEnvelope = await ApiClient.Connections.GetAsync(
                 senderType: "capability",
-                senderId: capabilityId.ToString()
+                senderId: _capabilityId.ToString()
             );
 
             var connections = connectionsEnvelope.Items;
 
-            Assert.Single(connections, c => c.ClientName == "VerbNoun");
-            Assert.Single(connections, c => c.ClientName == "channel1");
-            Assert.Single(connections, c => c.ClientName == "channel2");
+            connections.Single(c => c.ChannelName == "verbnoun");
+            connections.Single(c => c.ChannelName == "channel1");
+            connections.Single(c => c.ChannelName == "channel2");
         }
     }
 }

--- a/integration-tests/Harald.IntegrationTests/Features/Infrastructure/Model/ConnectionDto.cs
+++ b/integration-tests/Harald.IntegrationTests/Features/Infrastructure/Model/ConnectionDto.cs
@@ -5,7 +5,10 @@ namespace Harald.IntegrationTests.Features.Infrastructure.Model
         public string ClientType { get; set; }
         public string ClientId { get; set; }
         public string ClientName { get; set; }
+        
+        
         public string ChannelType { get; set; }
         public string ChannelId { get; set; }
+        public string ChannelName { get; set; }
     }
 }

--- a/integration-tests/Harald.IntegrationTests/Features/Infrastructure/Model/SlackConversationDto.cs
+++ b/integration-tests/Harald.IntegrationTests/Features/Infrastructure/Model/SlackConversationDto.cs
@@ -1,0 +1,8 @@
+namespace Harald.IntegrationTests.Features.Infrastructure.Model
+{
+    public class SlackConversationDto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/integration-tests/Harald.IntegrationTests/Features/Infrastructure/SlackApiServerSpyClient.cs
+++ b/integration-tests/Harald.IntegrationTests/Features/Infrastructure/SlackApiServerSpyClient.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Harald.IntegrationTests.Features.Infrastructure.Model;
 using Newtonsoft.Json;
 
 namespace Harald.IntegrationTests.Features.Infrastructure
@@ -48,6 +50,28 @@ namespace Harald.IntegrationTests.Features.Infrastructure
             var httpClient = new HttpClient();
 
             await httpClient.PostAsync(uri,null);
+        }
+
+        public async Task<SlackConversationDto> ChannelsCreateAsync(string channelName)
+        {
+            var uri = new Uri("http://localhost:1447/api/channels.create");
+            var payload = new {name = channelName };
+            var json = JsonConvert.SerializeObject(payload);
+
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var httpClient = new HttpClient();
+            var responseMessage = await httpClient.PostAsync(
+                uri,
+                content
+            );
+
+
+            var contentString = await responseMessage.Content.ReadAsStringAsync();
+            
+            dynamic deserializeObject = JsonConvert.DeserializeObject(contentString);
+
+            return new SlackConversationDto{Id = deserializeObject.Channel.Id, Name = deserializeObject.Channel.Name };
         }
     }
 }

--- a/local-development/slack-api-server-spy/server.js
+++ b/local-development/slack-api-server-spy/server.js
@@ -5,8 +5,8 @@ const port = process.env.port || 1447;
 const app = express();
 app.use(express.json());
 
-const interactions = [];
-const conversations = [];
+var interactions = [];
+var conversations = [];
 function collectRequestData(request) {
     let interaction = {
         path: request.path,
@@ -51,8 +51,8 @@ app.get("/api/usergroups.list", (req, res) => {
 app.post("/api/channels.create", async (req, res) => {
     collectRequestData(req);
 
-    let channel = { 
-        "Id": generateRandomString(9).toUpperCase(), 
+    let channel = {
+        "Id": generateRandomString(9).toUpperCase(),
         "Name": req.body.name
     };
     conversations.push(channel);
@@ -89,10 +89,40 @@ app.post("/api/pins.add", async (req, res) => {
     });
 });
 
+app.post("/api/channels.join", async (req, res) => {
+    collectRequestData(req);
+    
+    let channel = conversations
+    .find(function (conversation) { return (conversation.name == req.body.name); });
+    
+    if(channel === undefined){ 
+        channel = {
+            "Id": generateRandomString(9).toUpperCase(),
+            "Name": req.body.name
+        };
+        conversations.push(channel);
+    }
+
+    return res.json({
+        "Ok": true,
+        "Channel": channel
+    });
+});
+
 app.post("*", async (req, res) => {
     collectRequestData(req);
 
     return res.json({ success: true });
+});
+
+
+app.get("/api/conversations.list", (req, res) => {
+    collectRequestData(req);
+
+    return res.json({
+        "Ok": true,
+        "Channels" : conversations
+    });
 });
 
 
@@ -104,12 +134,14 @@ app.get("/api/usergroups.list", (req, res) => {
     });
 });
 
+
+
 function generateRandomString(length) {
-    var result           = '';
-    var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    var result = '';
+    var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
     var charactersLength = characters.length;
-    for ( var i = 0; i < length; i++ ) {
-       result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    for (var i = 0; i < length; i++) {
+        result += characters.charAt(Math.floor(Math.random() * charactersLength));
     }
     return result;
 }

--- a/src/Harald.Tests/TestDoubles/SlackFacadeSpy.cs
+++ b/src/Harald.Tests/TestDoubles/SlackFacadeSpy.cs
@@ -207,9 +207,14 @@ namespace Harald.Tests.TestDoubles
             return Task.FromResult(UserGroups.AsEnumerable());
         }
 
+        public readonly List<ChannelDto> Conversations = new List<ChannelDto>();
         public Task<GetConversationsResponse> GetConversations()
         {
-            throw new System.NotImplementedException();
+            return Task.FromResult(new GetConversationsResponse
+            {
+                Channels = Conversations,
+                Ok = true
+            });
         }
 
         public Task LeaveChannel(SlackChannelIdentifier channelIdentifier)

--- a/src/Harald.Tests/TestDoubles/SlackFacadeStub.cs
+++ b/src/Harald.Tests/TestDoubles/SlackFacadeStub.cs
@@ -21,6 +21,11 @@ namespace Harald.Tests.TestDoubles
 
         public bool SendNotificationToChannelCalled { get; private set; } = false;
 
+        public SlackFacadeStub()
+        {
+            _simulateFailOnSendMessage = false;
+        }
+
         public SlackFacadeStub(bool simulateFailOnSendMessage)
         {
             _simulateFailOnSendMessage = simulateFailOnSendMessage;

--- a/src/Harald.Tests/TestDoubles/SlackFacadeStub.cs
+++ b/src/Harald.Tests/TestDoubles/SlackFacadeStub.cs
@@ -93,7 +93,7 @@ namespace Harald.Tests.TestDoubles
         
         public Task<GetConversationsResponse> GetConversations()
         {
-            throw new System.NotImplementedException();
+           return Task.FromResult<GetConversationsResponse>(new GetConversationsResponse{Ok = true, Channels = new List<ChannelDto>()});
         }
 
         public Task<SendNotificationResponse> SendNotificationToChannel(SlackChannelIdentifier channelId, string message)

--- a/src/Harald.Tests/features/Connections/Infrastructure/Persistence/FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandlerTests.cs
+++ b/src/Harald.Tests/features/Connections/Infrastructure/Persistence/FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandlerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Harald.Infrastructure.Slack.Dto;
 using Harald.Tests.TestDoubles;
 using Harald.WebApi.Domain;
 using Harald.WebApi.Features.Connections.Domain.Model;
@@ -18,7 +19,7 @@ namespace Harald.Tests.features.Connections.Infrastructure.Persistence
         public async Task GIVEN_query_with_ChannelType_not_equal_to_ChannelTypeSlack_EXPECT_empty_result()
         {
             // Arrange
-            var sut = new FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(null);
+            var sut = new FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(null, null);
             var query = new FindConnectionsByClientTypeClientIdChannelTypeChannelId(
                 null,
                 null,
@@ -40,7 +41,7 @@ namespace Harald.Tests.features.Connections.Infrastructure.Persistence
         public async Task GIVEN_query_with_SenderType_not_equal_to_SenderTypeCapability_EXPECT_empty_result()
         {
             // Arrange
-            var sut = new FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(null);
+            var sut = new FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(null, null);
             var query = new FindConnectionsByClientTypeClientIdChannelTypeChannelId(
                 new ClientTypeTest(),
                 null,
@@ -82,8 +83,10 @@ namespace Harald.Tests.features.Connections.Infrastructure.Persistence
                 "NotTheChannelWeWant",
                 "slackUserGroupId"
             ));
+            
+            var slackFacadeSpy = new SlackFacadeSpy();
 
-            var sut = new FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(capabilityRepository);
+            var sut = new FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(capabilityRepository,slackFacadeSpy);
 
             var channelIdOfWantedChannel = new ChannelId(idOfWantedChannels);
             var query = new FindConnectionsByClientTypeClientIdChannelTypeChannelId(
@@ -130,8 +133,9 @@ namespace Harald.Tests.features.Connections.Infrastructure.Persistence
                 "slackChannelId",
                 "slackUserGroupId"
             ));
+            var slackFacadeSpy = new SlackFacadeSpy();
 
-            var sut = new FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(capabilityRepository);
+            var sut = new FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(capabilityRepository,slackFacadeSpy);
 
             var clientIdOfWantedSender = new ClientId(idOfWantedSender.ToString());
             var query = new FindConnectionsByClientTypeClientIdChannelTypeChannelId(
@@ -173,8 +177,9 @@ namespace Harald.Tests.features.Connections.Infrastructure.Persistence
                 "slackUserGroupId"
             ));
 
-
-            var sut = new FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(capabilityRepository);
+            var slackFacadeSpy = new SlackFacadeSpy();
+            slackFacadeSpy.Conversations.AddRange(new []{new ChannelDto{Id = "slackChannelId", Name = "slackChannelName"}});
+            var sut = new FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(capabilityRepository, slackFacadeSpy);
 
             var query = new FindConnectionsByClientTypeClientIdChannelTypeChannelId(
                 null,

--- a/src/Harald.WebApi/Features/Connections/Infrastructure/Persistence/FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler.cs
+++ b/src/Harald.WebApi/Features/Connections/Infrastructure/Persistence/FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler.cs
@@ -32,6 +32,11 @@ namespace Harald.WebApi.Features.Connections.Infrastructure.Persistence
         {
             var capabilities = await QueryCapabilities(query);
 
+            if (capabilities.Any() == false)
+            {
+                return Enumerable.Empty<Connection>();
+            }
+
             var ConversationIds = capabilities.Select(c => c.SlackChannelId.ToString());
 
             var channelDtos = await GetSlackConversationsByIds(ConversationIds);
@@ -64,20 +69,20 @@ namespace Harald.WebApi.Features.Connections.Infrastructure.Persistence
                     );
             }
 
-            if (query.ClientId == null || query.ClientId.IsEmpty) return capabilities;
-            {
-                Guid capabilityId;
-                var capabilityIdIsValid = Guid.TryParse(query.ClientId, out capabilityId);
-                if (capabilityIdIsValid == false)
-                {
-                    throw new ValidationException(
-                        $"The given capability id: '{query.ClientId}' is not valid. Expected format is Guid with 32 digits with 4 dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).");
-                }
+            if (query.ClientId == null || query.ClientId.IsEmpty) {return capabilities;}
 
-                capabilities = capabilities
-                    .Where(c =>
-                        c.Id.Equals(capabilityId));
+
+            Guid capabilityId;
+            var capabilityIdIsValid = Guid.TryParse(query.ClientId, out capabilityId);
+            if (capabilityIdIsValid == false)
+            {
+                throw new ValidationException(
+                    $"The given capability id: '{query.ClientId}' is not valid. Expected format is Guid with 32 digits with 4 dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).");
             }
+
+            capabilities = capabilities
+                .Where(c =>
+                    c.Id.Equals(capabilityId));
 
 
             return capabilities;
@@ -93,7 +98,7 @@ namespace Harald.WebApi.Features.Connections.Infrastructure.Persistence
             return relevantConversations;
         }
 
-        
+
         private IEnumerable<Connection> MergeIntoConnections(
             IEnumerable<Capability> capabilities,
             IEnumerable<ChannelDto> channelDtos
@@ -106,7 +111,7 @@ namespace Harald.WebApi.Features.Connections.Infrastructure.Persistence
                 var relevantCapability = capabilities.Where(c => c.SlackChannelId == channelDto.Id);
 
                 connections.AddRange(
-                    relevantCapability.Select(capability => 
+                    relevantCapability.Select(capability =>
                         new Connection(
                             new ClientTypeCapability(),
                             new ClientName(capability.Name),

--- a/src/Harald.WebApi/Features/Connections/Infrastructure/Persistence/FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler.cs
+++ b/src/Harald.WebApi/Features/Connections/Infrastructure/Persistence/FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Harald.Infrastructure.Slack;
+using Harald.Infrastructure.Slack.Dto;
 using Harald.WebApi.Domain;
 using Harald.WebApi.Domain.Queries;
 using Harald.WebApi.Features.Connections.Domain.Model;
@@ -13,24 +15,43 @@ namespace Harald.WebApi.Features.Connections.Infrastructure.Persistence
         FindConnectionsByClientTypeClientIdChannelTypeChannelId, IEnumerable<Connection>>
     {
         private readonly ICapabilityRepository _capabilityRepository;
+        private readonly ISlackFacade _slackFacade;
 
         public FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler(
-            ICapabilityRepository capabilityRepository)
+            ICapabilityRepository capabilityRepository,
+            ISlackFacade slackFacade
+        )
         {
             _capabilityRepository = capabilityRepository;
+            _slackFacade = slackFacade;
         }
 
         public async Task<IEnumerable<Connection>> HandleAsync(
+            FindConnectionsByClientTypeClientIdChannelTypeChannelId query
+        )
+        {
+            var capabilities = await QueryCapabilities(query);
+
+            var ConversationIds = capabilities.Select(c => c.SlackChannelId.ToString());
+
+            var channelDtos = await GetSlackConversationsByIds(ConversationIds);
+
+            var connections = MergeIntoConnections(capabilities, channelDtos);
+
+            return connections;
+        }
+
+        private async Task<IEnumerable<Capability>> QueryCapabilities(
             FindConnectionsByClientTypeClientIdChannelTypeChannelId query)
         {
             if (query.ChannelType != null && !query.ChannelType.IsEmpty && !(query.ChannelType is ChannelTypeSlack))
             {
-                return Enumerable.Empty<Connection>();
+                return Enumerable.Empty<Capability>();
             }
 
             if (query.ClientType != null && !query.ClientType.IsEmpty && !(query.ClientType is ClientTypeCapability))
             {
-                return Enumerable.Empty<Connection>();
+                return Enumerable.Empty<Capability>();
             }
 
             var capabilities = await _capabilityRepository.GetAll();
@@ -43,35 +64,62 @@ namespace Harald.WebApi.Features.Connections.Infrastructure.Persistence
                     );
             }
 
-            if (query.ClientId != null && !query.ClientId.IsEmpty)
+            if (query.ClientId == null || query.ClientId.IsEmpty) return capabilities;
             {
                 Guid capabilityId;
                 var capabilityIdIsValid = Guid.TryParse(query.ClientId, out capabilityId);
-                if(capabilityIdIsValid == false)
+                if (capabilityIdIsValid == false)
                 {
-                    throw new ValidationException($"The given capability id: '{query.ClientId}' is not valid. Expected format is Guid with 32 digits with 4 dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).");
+                    throw new ValidationException(
+                        $"The given capability id: '{query.ClientId}' is not valid. Expected format is Guid with 32 digits with 4 dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).");
                 }
-                
+
                 capabilities = capabilities
                     .Where(c =>
                         c.Id.Equals(capabilityId));
             }
 
-            var connections = capabilities.Select(ConvertCapabilityToConnection);
 
-            return connections;
+            return capabilities;
         }
 
-        private Connection ConvertCapabilityToConnection(Capability capability)
+        private async Task<IEnumerable<ChannelDto>> GetSlackConversationsByIds(IEnumerable<string> channelIds)
         {
-            return new Connection(
-                new ClientTypeCapability(),
-                new ClientName(capability.Name), 
-                new ClientId(capability.Id.ToString()),
-                new ChannelTypeSlack(),
-                ChannelName.Create(capability.Name),
-                new ChannelId(capability.SlackChannelId)
-            );
+            var conversations = await _slackFacade.GetConversations();
+
+            var relevantConversations = conversations.Channels.Where(c => channelIds.Contains(c.Id));
+
+
+            return relevantConversations;
+        }
+
+        
+        private IEnumerable<Connection> MergeIntoConnections(
+            IEnumerable<Capability> capabilities,
+            IEnumerable<ChannelDto> channelDtos
+        )
+        {
+            var connections = new List<Connection>();
+
+            foreach (var channelDto in channelDtos)
+            {
+                var relevantCapability = capabilities.Where(c => c.SlackChannelId == channelDto.Id);
+
+                connections.AddRange(
+                    relevantCapability.Select(capability => 
+                        new Connection(
+                            new ClientTypeCapability(),
+                            new ClientName(capability.Name),
+                            new ClientId(capability.Id.ToString()),
+                            new ChannelTypeSlack(),
+                            ChannelName.Create(channelDto.Name),
+                            new ChannelId(capability.SlackChannelId)
+                        )
+                    )
+                );
+            }
+
+            return connections;
         }
     }
 }


### PR DESCRIPTION
The FindConnectionsByClientTypeClientIdChannelTypeChannelIdHandler 
Will pulll capabilites from database and slack conversations from slack api
Then merge them based on capability SlackChannelId & channel Id into a connection

The issue we solve is that the capability db does not contain slack channel names but a connection requires it.