### PR TITLE
Added health endpoint; Extended health check with Slack

### DIFF
--- a/src/Harald.WebApi/Enablers/SlackHealthCheck/SlackHealthProbe.cs
+++ b/src/Harald.WebApi/Enablers/SlackHealthCheck/SlackHealthProbe.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Harald.Infrastructure.Slack;
+using Harald.Infrastructure.Slack.Http.Response.Conversation;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Harald.WebApi.Enablers.SlackHealthCheck
+{
+    public class SlackHealthProbe : IHealthCheck
+    {
+        private ISlackFacade _slackFacade;
+
+        public SlackHealthProbe(ISlackFacade slackFacade)
+        {
+            _slackFacade = slackFacade;
+        }
+        
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
+        {
+            GetConversationsResponse result;
+            try
+            {
+                result = await _slackFacade.GetConversations();
+            }
+            catch (Exception exception)
+            {
+                return HealthCheckResult.Degraded("Unable to get expected response from Slack");
+            }
+
+            if (result.Ok)
+            {
+                return HealthCheckResult.Healthy("Slack is capable of returning an response from their API");
+            }
+
+            return HealthCheckResult.Degraded("Unable to get expected response from Slack");
+        }
+    }
+}

--- a/src/Harald.WebApi/Startup.cs
+++ b/src/Harald.WebApi/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using Harald.Infrastructure.Slack;
 using Harald.WebApi.Application.EventHandlers;
@@ -11,16 +12,20 @@ using Harald.WebApi.Enablers.SlackHealthCheck;
 using Harald.WebApi.Features.Connections.Configuration;
 using Harald.WebApi.Infrastructure.Messaging;
 using Harald.WebApi.Infrastructure.Persistence;
-using Harald.WebApi.Infrastructure.Serialization;
 using Harald.WebApi.Infrastructure.Services;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Prometheus;
+using JsonSerializer = Harald.WebApi.Infrastructure.Serialization.JsonSerializer;
 
 namespace Harald.WebApi
 {
@@ -146,6 +151,26 @@ namespace Harald.WebApi
             app.UseHttpMetrics();
 
             app.UseHealthChecks("/health");
+            
+            // Same as above, but in JSON and more descriptive/expanded
+            app.UseHealthChecks("/health-json", new HealthCheckOptions()
+            {
+                ResponseWriter = async (HttpContext httpContext, HealthReport result) =>
+                {
+                    httpContext.Response.ContentType = "application/json";
+
+                    var json = new JObject(
+                        new JProperty("status", result.Status.ToString()),
+                        new JProperty("results", new JObject(result.Entries.Select(pair =>
+                            new JProperty(pair.Key, new JObject(
+                                new JProperty("status", pair.Value.Status.ToString()),
+                                new JProperty("description", pair.Value.Description),
+                                new JProperty("data", new JObject(pair.Value.Data.Select(
+                                    p => new JProperty(p.Key, p.Value))))))))));
+                    await httpContext.Response.WriteAsync(
+                        json.ToString(Formatting.Indented));
+                }
+            });
 
             app.UseMvc();
 

--- a/src/Harald.WebApi/Startup.cs
+++ b/src/Harald.WebApi/Startup.cs
@@ -7,6 +7,7 @@ using Harald.WebApi.Domain.Events;
 using Harald.WebApi.Enablers.KafkaMessageConsumer.Configuration;
 using Harald.WebApi.Enablers.Metrics.Configuration;
 using Harald.WebApi.Enablers.PrometheusHealthCheck.Configuration;
+using Harald.WebApi.Enablers.SlackHealthCheck;
 using Harald.WebApi.Features.Connections.Configuration;
 using Harald.WebApi.Infrastructure.Messaging;
 using Harald.WebApi.Infrastructure.Persistence;
@@ -76,6 +77,7 @@ namespace Harald.WebApi
 
             services.AddHealthChecks()
                 .AddCheck("self", () => HealthCheckResult.Healthy())
+                .AddCheck<SlackHealthProbe>(name: "slack", tags: new [] {"backing services", "slack"})
                 .AddNpgSql(connectionString, tags: new[] {"backing services", "postgres"});
 
             services.AddSwaggerDocument();
@@ -142,6 +144,8 @@ namespace Harald.WebApi
             app.UseSwaggerUi3();
 
             app.UseHttpMetrics();
+
+            app.UseHealthChecks("/health");
 
             app.UseMvc();
 


### PR DESCRIPTION
- Added "/health" endpoint
- Added "/health-json" endpoint that gives more data

  Looks a bit like this:
  ```
  {
    "status": "Healthy",
    "results": {
      "self": {
        "status": "Healthy",
        "description": null,
        "data": {}
      },
      "slack": {
        "status": "Healthy",
        "description": "Slack is capable of returning an response from their API",
        "data": {}
      },
      "npgsql": {
        "status": "Healthy",
        "description": null,
        "data": {}
      }
    }
  }
  ```

- Created health check for Slack that utilizes existing SlackFacade.
- Health check for database was already available, merely just needed to be exposed.

I was unsure whether to use degraded or unhealthy, I'd appreciate your experienced input @wcarlsen 