### PR TITLE
Added retry handling when Slack throttles Harald

### DIFF
--- a/src/Harald.Infrastructure.Slack/Harald.Infrastructure.Slack.csproj
+++ b/src/Harald.Infrastructure.Slack/Harald.Infrastructure.Slack.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />


### PR DESCRIPTION
This PR partially remedies the ongoing issue with Slack throttling us, by looking for a 'retry-after' header and using the value from said header to wait before retrying the initial request. Perhaps we should add cache for certain requests?