### PR TITLE
Locking infrastructure modules versions

### DIFF
--- a/build/ecr-harald-dbmigrations-repo/terraform.tfvars
+++ b/build/ecr-harald-dbmigrations-repo/terraform.tfvars
@@ -2,7 +2,7 @@ terragrunt {
   # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
   # working directory, into a temporary folder, and execute your Terraform commands in that folder.
   terraform {
-    source = "git::https://github.com/dfds/infrastructure-modules.git//compute/ecr-repo"
+    source = "git::https://github.com/dfds/infrastructure-modules.git//compute/ecr-repo?ref=0.1.78"
   }
 
   # Include all settings from the root terraform.tfvars file

--- a/build/ecr-harald-repo/terraform.tfvars
+++ b/build/ecr-harald-repo/terraform.tfvars
@@ -2,7 +2,7 @@ terragrunt {
   # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
   # working directory, into a temporary folder, and execute your Terraform commands in that folder.
   terraform {
-    source = "git::https://github.com/dfds/infrastructure-modules.git//compute/ecr-repo"
+    source = "git::https://github.com/dfds/infrastructure-modules.git//compute/ecr-repo?ref=0.1.78"
   }
 
   # Include all settings from the root terraform.tfvars file

--- a/infrastructure/harald-postgres/terraform.tfvars
+++ b/infrastructure/harald-postgres/terraform.tfvars
@@ -2,7 +2,7 @@ terragrunt {
   # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
   # working directory, into a temporary folder, and execute your Terraform commands in that folder.
   terraform {
-    source = "git::https://github.com/dfds/infrastructure-modules.git//database/postgres"
+    source = "git::https://github.com/dfds/infrastructure-modules.git//database/postgres?ref=0.1.78"
   }
 
   # Include all settings from the root terraform.tfvars file


### PR DESCRIPTION
Locking infrastructure modules versions to not break while upgrading to Terraform 0.12.