### PR TITLE
Changed regex pattern causing collision issues

### DIFF
--- a/src/Harald.WebApi/Domain/UserGroupHandle.cs
+++ b/src/Harald.WebApi/Domain/UserGroupHandle.cs
@@ -49,7 +49,7 @@ namespace Harald.WebApi.Domain
 
             if (name.Contains("-"))
             {
-                regExPattern = @"[a-zA-Z1-9]+-[a-zA-Z1-9]+";
+                regExPattern = @"[a-zA-Z1-9]+[a-zA-Z1-9]+";
             }
             else
             {


### PR DESCRIPTION
With the current regex pattern, the following would match
![image](https://user-images.githubusercontent.com/1633308/79236729-a1d75400-7e6d-11ea-84e4-d442e7d52819.png)

Sandbox-emclaMembers is turned into sandbox-emclamembers

Sandbox-emcla-topicsMembers is turned into sandbox-emcla

The first one, 'Sandbox-emclaMembers' stems from the Capability 'sandbox-emcla', that also has a corrosponding Slack channel with the exact same name. Turns out, UserGroup handles aren't unique, and will clash with Channel names, which means the second line will fail.

With a **very** minor change in the regex pattern, it looks like this
![image](https://user-images.githubusercontent.com/1633308/79236918-dc40f100-7e6d-11ea-9234-61a71684cffb.png)

Sandbox-emclaMembers is turned into sandbox-emclamembers (same as before, and that is fine)

Sandbox-emcla-topicsMembers is turned into sandbox-emcla-topicsmembers

The change ensures that all of the Capability name is included in the handle.