### PR TITLE
removed rolearn

### DIFF
--- a/src/Harald.Tests/Builders/DomainEventBuilder.cs
+++ b/src/Harald.Tests/Builders/DomainEventBuilder.cs
@@ -8,7 +8,6 @@ namespace Harald.Tests.Builders
     {
         public static Guid ContextId { get; set; } = Guid.NewGuid();
         public static string AccountId { get; set; } = "1234567890";
-        public static string RoleArn { get; set; } = "arn:aws:iam::1234567890:role/pax-bookings-A43aS";
         public static string RoleEmail { get; set; } = "aws.pax-bookings-a43as@dfds.com";
 
         public static Guid CapabilityId { get; set; } = Guid.NewGuid();
@@ -28,7 +27,6 @@ namespace Harald.Tests.Builders
             data.contextId = ContextId;
             data.contextName = ContextName;
             data.accountId = AccountId;
-            data.roleArn = RoleArn;
             data.roleEmail = RoleEmail;
 
             return BuildGeneralDomainEvent("aws_context_account_created", data);

--- a/src/Harald.Tests/Domain/AWSContextAccountCreatedDomainEventTests.cs
+++ b/src/Harald.Tests/Domain/AWSContextAccountCreatedDomainEventTests.cs
@@ -22,7 +22,6 @@ namespace Harald.Tests.Domain
             Assert.Equal(DomainEventBuilder.CapabilityName, awsContextAccountCreatedDomainEvent.Payload.CapabilityName);
             Assert.Equal(DomainEventBuilder.CapabilityId, awsContextAccountCreatedDomainEvent.Payload.CapabilityId);
             Assert.Equal(DomainEventBuilder.CapabilityRootId, awsContextAccountCreatedDomainEvent.Payload.CapabilityRootId);
-            Assert.Equal(DomainEventBuilder.RoleArn, awsContextAccountCreatedDomainEvent.Payload.RoleArn);
             Assert.Equal(DomainEventBuilder.RoleEmail, awsContextAccountCreatedDomainEvent.Payload.RoleEmail);
             Assert.Equal(DomainEventBuilder.AccountId, awsContextAccountCreatedDomainEvent.Payload.AccountId);
         }

--- a/src/Harald.WebApi/Domain/Events/AWSContextAccountCreatedDomainEvent.cs
+++ b/src/Harald.WebApi/Domain/Events/AWSContextAccountCreatedDomainEvent.cs
@@ -14,18 +14,17 @@ namespace Harald.WebApi.Domain.Events
     }
 
 
-public class AWSContextAccountCreatedData
-{
-    public Guid CapabilityId { get; }
-    public string CapabilityName { get; }
-    public string CapabilityRootId { get; }
-    public Guid ContextId { get; }
-    public string ContextName { get; }
-    public string AccountId { get;  }
-        public string RoleArn { get; }
+    public class AWSContextAccountCreatedData
+    {
+        public Guid CapabilityId { get; }
+        public string CapabilityName { get; }
+        public string CapabilityRootId { get; }
+        public Guid ContextId { get; }
+        public string ContextName { get; }
+        public string AccountId { get;  }
         public string RoleEmail { get;  }
 
-        public AWSContextAccountCreatedData(Guid capabilityId, string capabilityName, string capabilityRootId, Guid contextId, string contextName, string accountId, string roleArn, string roleEmail)
+        public AWSContextAccountCreatedData(Guid capabilityId, string capabilityName, string capabilityRootId, Guid contextId, string contextName, string accountId, string roleEmail)
         {
             CapabilityId = capabilityId;
             CapabilityName = capabilityName;
@@ -33,7 +32,6 @@ public class AWSContextAccountCreatedData
             ContextId = contextId;
             ContextName = contextName;
             AccountId = accountId;
-            RoleArn = roleArn;
             RoleEmail = roleEmail;
 
         }


### PR DESCRIPTION
This PR will remove the RoleArn from the AWSContextAccountCreated event because we won't be putting it in the payload anymore via org-account-context