### PR TITLE
Changed DB IDs from uuid to varchar(255)

### DIFF
--- a/db/migrations/20230502104015_id_changed_type.sql
+++ b/db/migrations/20230502104015_id_changed_type.sql
@@ -1,0 +1,5 @@
+-- 2023-05-02 10:40:15 : capability_id_changed_type
+
+alter table public."Capability" alter column "Id" type varchar(255);
+alter table public."CapabilityMember" alter column "Id" type varchar(255);
+alter table public."CapabilityMember" alter column "CapabilityId" type varchar(255);

--- a/db/migrations/20230502104015_id_changed_type.sql
+++ b/db/migrations/20230502104015_id_changed_type.sql
@@ -1,5 +1,11 @@
 -- 2023-05-02 10:40:15 : capability_id_changed_type
 
+ALTER TABLE "CapabilityMember"
+DROP CONSTRAINT "FK_CapabilityMember_CapabilityId_CapabilitySlackChannelId";
+
 alter table public."Capability" alter column "Id" type varchar(255);
 alter table public."CapabilityMember" alter column "Id" type varchar(255);
 alter table public."CapabilityMember" alter column "CapabilityId" type varchar(255);
+
+ALTER TABLE "CapabilityMember"
+ADD CONSTRAINT "FK_CapabilityMember_CapabilityId_CapabilitySlackChannelId" FOREIGN KEY ("CapabilityId", "CapabilitySlackChannelId") REFERENCES "Capability" ("Id", "SlackChannelId") ON DELETE RESTRICT;


### PR DESCRIPTION
Tested by dumping the prod Harald database, applying the dump to a local postgres db, and then applied the migration. Check the values in prod versus locally afterwards, and it seems to match.